### PR TITLE
using req.body if it has been pre-parsed

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "type-is": "^1.2.0",
-    "raw-body": "^1.1.6"
+    "raw-body": "^2.1.4"
   },
   "contributors": [
     {


### PR DESCRIPTION
to avoid hanging because the req has already been consumed, similar to 32  and
to support other middleware which have already consumed the body such as body-parser or swagger-framework and
